### PR TITLE
[IMP] initialize empty database with language

### DIFF
--- a/entrypoint.d/800-auto-init-empty-database
+++ b/entrypoint.d/800-auto-init-empty-database
@@ -29,5 +29,5 @@ function pg_is_empty() {
 
 if [ "${PGDATABASE,,}" != "" ] && pg_exists && pg_is_empty; then
     echo "Database is empty. Initializing..."
-    $ODOO_SERVER --stop -i saas_client_adhoc --no-http -c $ODOO_RC
+    $ODOO_SERVER -c $ODOO_RC -d $PGDATABASE --no-http --stop --init=saas_client_adhoc --load-language=${ODOO_INITIAL_LANGUAGE:-en_US}
 fi


### PR DESCRIPTION
The initial language must be set in the ODOO_INITIAL_LANGUAGE env variable. It defaults to 'en_US' if not set.

Additionally, avoid using command line arguments shorthand to pass options and explicitly pass the database name, to make the script more readable.